### PR TITLE
Fix "Undefined array key" warning

### DIFF
--- a/dovecot_ident.php
+++ b/dovecot_ident.php
@@ -17,8 +17,11 @@ class dovecot_ident extends rcube_plugin
 
   function add_ident($args)
   {
-    $args['preauth_ident'] = $args['preauth_ident'] ? array_merge($args['preauth_ident'], array('x-originating-ip' => $_SERVER['REMOTE_ADDR']))
-									: array('x-originating-ip' => $_SERVER['REMOTE_ADDR']);
+    if (isset($args['preauth_ident'])) {
+      $args['preauth_ident'] = array_merge($args['preauth_ident'], array('x-originating-ip' => $_SERVER['REMOTE_ADDR']));
+    } else {
+      $args['preauth_ident'] = array('x-originating-ip' => $_SERVER['REMOTE_ADDR']);
+    }
     return $args;
   }
 }


### PR DESCRIPTION
I always got the following warning:

`PHP Warning:  Undefined array key "preauth_ident" in /var/www/html/plugins/dovecot_ident/dovecot_ident.php on line 20`

This PR fixes the warning with checking if the `preauth_ident` key does exist before accessing it.